### PR TITLE
Fix recipes so that the flux storages are craftable

### DIFF
--- a/src/main/resources/data/fluxnetworks/recipes/basic_flux_storage.json
+++ b/src/main/resources/data/fluxnetworks/recipes/basic_flux_storage.json
@@ -11,7 +11,7 @@
       "item": "fluxnetworks:flux_block"
     },
     "g": {
-      "tag": "forge:glass_panes"
+      "tag": "c:glass_panes"
     }
   },
   "result": {

--- a/src/main/resources/data/fluxnetworks/recipes/gargantuan_flux_storage.json
+++ b/src/main/resources/data/fluxnetworks/recipes/gargantuan_flux_storage.json
@@ -11,7 +11,7 @@
       "item": "fluxnetworks:herculean_flux_storage"
     },
     "g": {
-      "tag": "forge:glass_panes"
+      "tag": "c:glass_panes"
     }
   },
   "result": {

--- a/src/main/resources/data/fluxnetworks/recipes/herculean_flux_storage.json
+++ b/src/main/resources/data/fluxnetworks/recipes/herculean_flux_storage.json
@@ -11,7 +11,7 @@
       "item": "fluxnetworks:basic_flux_storage"
     },
     "g": {
-      "tag": "forge:glass_panes"
+      "tag": "c:glass_panes"
     }
   },
   "result": {


### PR DESCRIPTION
The recipes previously used the tag `forge:glass_panes`. Updated to use `c:glass_panes`. (neoforge will eventually be migrating `c:glass_panes` as well.)

Also, issues are currently disabled on this repo, so it is impossible to report any bugs (like this one) that are found.